### PR TITLE
Removing DATA_VERSION reference

### DIFF
--- a/sz_tools/sz_create_project
+++ b/sz_tools/sz_create_project
@@ -47,7 +47,6 @@ def get_version_details(sz_root_path: Path) -> List[str]:
 
     details: List[str] = []
     details.append(version_details.get("BUILD_VERSION", ""))
-    details.append(version_details.get("DATA_VERSION", ""))
 
     if not all(details):
         print(f"\nERROR: Problem reading values from version details, missing value(s) - {details}")


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #51

## Why was change needed

DATA_VERSION was removed from the g2BuildVersion.json file causing sz_create_project to fail 

## What does change improve

Keeps it functional
