### PR TITLE
#391 sz_explorer: strip null/empty entries from UNMAPPED_DATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
-### Fixed
+## [0.0.41] - 2026-05-18
+
+### Fixed in 0.0.41
 
 - `sz_explorer`: mappable attributes with null/empty values no longer appear in Additional Data (#391)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- `sz_explorer`: mappable attributes with null/empty values no longer appear in Additional Data (#391)
+
 ## [0.0.40] - 2026-04-23
 
 ### Fixed in 0.0.40

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sz-python-tools"
-version = "0.0.40"
+version = "0.0.41"
 description = "Senzing Python Tools"
 authors = [{ name = "senzing", email = "support@senzing.com" }]
 readme = "README.md"

--- a/sz_tools/sz_explorer
+++ b/sz_tools/sz_explorer
@@ -1543,6 +1543,50 @@ class EdaReports:
                     )
 
 
+def _strip_null_values(value):
+    """Recursively drop None and empty-string entries from nested dicts/lists.
+
+    Keeps 0, False, and other non-null values. Returns None if the container
+    collapses to empty so callers can drop it from a parent.
+    """
+    if isinstance(value, dict):
+        cleaned = {}
+        for k, v in value.items():
+            if v is None or v == "":
+                continue
+            cv = _strip_null_values(v)
+            if cv is None:
+                continue
+            cleaned[k] = cv
+        return cleaned or None
+    if isinstance(value, list):
+        cleaned = []
+        for item in value:
+            if item is None or item == "":
+                continue
+            ci = _strip_null_values(item)
+            if ci is None:
+                continue
+            cleaned.append(ci)
+        return cleaned or None
+    return value
+
+
+def _clean_unmapped_data(node):
+    """Walk a parsed engine response and strip null/empty entries from every
+    UNMAPPED_DATA dict found anywhere in the structure. Mutates in place.
+    """
+    if isinstance(node, dict):
+        if "UNMAPPED_DATA" in node:
+            cleaned = _strip_null_values(node["UNMAPPED_DATA"])
+            node["UNMAPPED_DATA"] = cleaned if cleaned else {}
+        for v in node.values():
+            _clean_unmapped_data(v)
+    elif isinstance(node, list):
+        for item in node:
+            _clean_unmapped_data(item)
+
+
 class EdaSdkWrapper:
 
     def __init__(self, engine_config, **kwargs):
@@ -1692,6 +1736,8 @@ class EdaSdkWrapper:
             response_data: Dict[str, Any] = json.loads(response)
         except SzError as err:
             raise SzError(f"{api_name}: {err}") from None
+
+        _clean_unmapped_data(response_data)
 
         if self.mask_pii:
             mask_json_pii(response_data, self.mask_pii)


### PR DESCRIPTION
Closes #391.

## Summary
- Mappable attributes whose source value was null/empty (e.g. `DATE: null`, `STATUS: ""`, `NAME_MIDDLE: ""`, nested `ADDR_CITY: null`) were returned by the engine inside `UNMAPPED_DATA` and rendered as noise in `sz_explorer`'s "Additional Data" column.
- Fix lives at the SDK-wrapper boundary: `EdaSdkWrapper.call_sdk` now passes every parsed engine response through a recursive cleaner before PII masking, call-cache append, and return. One choke point covers `get_entity`, `compare_entities`, the call-cache export, and any future consumer.
- Rules: drop `null` and `""`, keep `0` / `False` / other non-null values, recurse into nested dicts and lists, drop nested containers that collapse to empty.

## Test plan
- [ ] `sz_explorer` → `get 17` (Darla Anderson): `DATE: None` and `STATUS:` no longer appear; `AMOUNT: 0` still does; nested FEATURES shows only non-null fields.
- [ ] `sz_explorer` → `compare <id1> <id2>` exercises the second call site cleanly.
- [ ] `export call cache` shows the cleaned response (consistent debugging output).
- [ ] `make lint` passes (pylint, mypy, black, flake8, isort, bandit).

---

Resolves #391