### PR TITLE
ci: allow Senzing SDK cask under Homebrew 6.0 tap trust

### DIFF
--- a/.github/workflows/pytest-darwin.yaml
+++ b/.github/workflows/pytest-darwin.yaml
@@ -14,6 +14,11 @@ concurrency:
 env:
   PYTHONPATH: ${{ github.workspace }}/src
   SENZING_TOOLS_DATABASE_URL: sqlite3://na:na@nowhere/tmp/sqlite/G2C.db
+  # Homebrew 6.0 (2026-06-11) added tap trust, which refuses to load the
+  # migration-redirected `senzingsdk` cask from the third-party
+  # `senzing/senzingsdk` tap. Opt out during the transition so the Senzing SDK
+  # install action's `brew install --cask` succeeds on macOS runners.
+  HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
 
 permissions: {}
 


### PR DESCRIPTION
## Problem

All `production-v4` macOS pytest jobs are failing on `main` (scheduled run) and on every open PR (including #411). The break is **environmental, not caused by any PR** — the macOS runner image picked up **Homebrew 6.0** (released 2026-06-11), which introduced [tap trust](https://docs.brew.sh/Tap-Trust).

The `Install Senzing SDK` step fails with:

```
##[error]Refusing to load cask senzing/senzingsdk/senzingsdk from untrusted tap senzing/senzingsdk.
Run `brew trust --cask senzing/senzingsdk/senzingsdk` or `brew trust senzing/senzingsdk` to trust it.
```

The official `cask_tap_migrations` redirect the short cask name `senzingsdk` to the third-party `senzing/senzingsdk` tap, and Homebrew 6.0 now refuses to load an auto-redirected cask from an untrusted tap. (`staging-v4` uses a differently-named cask and currently only warns.)

## Fix

Set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` at the workflow level in `pytest-darwin.yaml` so the install action's `brew install --cask` is allowed during Homebrew's transition window.

This is the documented transition escape hatch. The durable fix belongs upstream in [`senzing-factory/github-action-install-senzing-sdk`](https://github.com/senzing-factory/github-action-install-senzing-sdk) (it should `brew trust` the tap it installs); this unblocks CI in the meantime.

## Notes

- Fixes the macOS CI failures seen in #411 — once this lands, #411 just needs `@dependabot rebase`.
- Also green again: `main`'s nightly `Pytest darwin` schedule.